### PR TITLE
Version compatible avec protocole ConcertV3

### DIFF
--- a/tpe.py
+++ b/tpe.py
@@ -30,7 +30,7 @@ def send_instruction(ipTPE,portTPE,cents):
 
     if cents is not None:
         print("je retiens la valeur suivante: ",cents," centimes d'euros")
-        MESSAGE = bytes("00000"+cents+"000978", 'utf-8')
+        MESSAGE = bytes("CZ0040300CJ012247300123456CA00201CB005"+cents+"CD0010CE003978", 'utf-8')
         print("j'envoie ",MESSAGE.decode("UTF-8"),"sur ",ipTPE,":",portTPE)
         print("en attente de la réponse du terminal")
 


### PR DESCRIPTION
Il s'agit d'une version compatible avec le protocole de caisse ConcertV3 (le seul disponible sur mon TPE). 
Je compte rajouter une variable dans le fichier de config pour spécifier le protocole utilisé pour communiquer avec le TPE pour pouvoir continuer à utiliser votre implémentation mais je ne trouve pas le protocole de TPE auquel l'implémentation actuelle fait référence. 

Fait à partir de ces sources:
- https://forum.pcsoft.fr/fr-FR/pcsoft.fr.windev/247762-tpe-protocole-concert-271034/read.awp
- https://www.youtube.com/watch?v=lrpHbF1bEkA